### PR TITLE
feat(create bucket): implement create bucket function

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,4 +12,5 @@ import (
 type Client interface {
 	GenerateAssignment(ctx context.Context, experimentLabel string, userID string) (*assignments.Assignment, error)
 	CreateExperiment(ctx context.Context, experiment *experiments.Experiment) (*experiments.Experiment, error)
+	CreateBucket(ctx context.Context, bucket *experiments.Bucket) (*experiments.Bucket, error)
 }

--- a/experiments/bucket.go
+++ b/experiments/bucket.go
@@ -1,5 +1,10 @@
 package experiments
 
+const (
+	BucketLabelControl   = "control"
+	BucketLabelTreatment = "treatment"
+)
+
 type Bucket struct {
 	Label             string  `json:"label"`
 	ExperimentID      string  `json:"experimentID"`

--- a/experiments/fixtures/fixtures.go
+++ b/experiments/fixtures/fixtures.go
@@ -24,12 +24,14 @@ func Buckets() []*experiments.Bucket {
 		&experiments.Bucket{
 			AllocationPercent: 0.2,
 			IsControl:         true,
-			Label:             "control",
+			Label:             experiments.BucketLabelControl,
 			Payload:           "do_not_deliver",
+			ExperimentID:      "experiment_id",
 		},
 		&experiments.Bucket{
 			AllocationPercent: 0.8,
-			Label:             "treatment",
+			Label:             experiments.BucketLabelTreatment,
+			ExperimentID:      "experiment_id",
 		},
 	}
 }

--- a/http/client.go
+++ b/http/client.go
@@ -79,6 +79,31 @@ func (c *HttpClient) CreateExperiment(ctx context.Context, experiment *experimen
 	return experimentCreated, err
 }
 
+func (c *HttpClient) CreateBucket(ctx context.Context, bucket *experiments.Bucket) (*experiments.Bucket, error) {
+	url := c.address + createBucketPath(bucket.ExperimentID)
+
+	payload, err := json.Marshal(bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(c.login, c.password)
+
+	body, err := executeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketCreated := &experiments.Bucket{}
+	err = json.Unmarshal(body, bucketCreated)
+	return bucketCreated, err
+}
+
 func (c *HttpClient) GetExperiments(ctx context.Context) ([]*experiments.Experiment, error) {
 	return nil, nil
 }

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -55,8 +55,25 @@ func (suite *HttpTestSuite) TestCreateExperiment() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(res)
 	suite.Require().NotEmpty(res.ID)
+
 	suite.EqualValues(experiment.ApplicationName, res.ApplicationName)
 	suite.EqualValues(experiment.Label, res.Label)
+}
+
+func (suite *HttpTestSuite) TestCreateBucket() {
+	buckets := fixtures.Buckets()
+
+	res, err := suite.client.CreateBucket(context.Background(), buckets[0])
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+	suite.Require().NotEmpty(res.State)
+
+	suite.EqualValues(buckets[0].AllocationPercent, res.AllocationPercent)
+	suite.EqualValues(buckets[0].IsControl, res.IsControl)
+	suite.EqualValues(buckets[0].Label, res.Label)
+	suite.EqualValues(buckets[0].Payload, res.Payload)
+	suite.EqualValues(buckets[0].ExperimentID, res.ExperimentID)
 }
 
 func TestHttpTestSuite(t *testing.T) {

--- a/http/mockserver/create_bucket.go
+++ b/http/mockserver/create_bucket.go
@@ -1,0 +1,24 @@
+package mockserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/inloco/go-wasabi/experiments"
+	"github.com/inloco/go-wasabi/experiments/fixtures"
+)
+
+const (
+	createBucketPath           = "/api/v1/experiments/experiment_id/buckets"
+	createBucketResponseStatus = http.StatusOK
+)
+
+func handleCreateBucket(w http.ResponseWriter, req *http.Request) {
+	bucket := fixtures.Buckets()
+	bucket[0].State = experiments.BucketStateOpen
+
+	payload, _ := json.Marshal(bucket[0])
+
+	w.Write([]byte(payload))
+	w.WriteHeader(createBucketResponseStatus)
+}

--- a/http/mockserver/test_server.go
+++ b/http/mockserver/test_server.go
@@ -23,6 +23,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		handleGenerateAssignemnt(w, req)
 	case req.Method == http.MethodPost && req.URL.EscapedPath() == createExperimentPath:
 		handleCreateExperiment(w, req)
+	case req.Method == http.MethodPost && req.URL.EscapedPath() == createBucketPath:
+		handleCreateBucket(w, req)
 	default:
 		failureMessage := fmt.Sprintf(
 			"test server does not recognize the request %s %s",

--- a/http/paths.go
+++ b/http/paths.go
@@ -8,6 +8,7 @@ const (
 	generateAssignmentPathFormat = "/api/v1/assignments/applications/%s/experiments/%s/users/%s"
 
 	createExperimentPathFormat  = "/api/v1/experiments"
+	createBucketPathFormat      = "/api/v1/experiments/%s/buckets"
 	getExperimentsPathFormat    = "/api/v1/experiments"
 	getExperimentByIDPathFormat = "/api/v1/experiments/%s"
 )
@@ -23,6 +24,10 @@ func generateAssignmentPath(applicationName, experimentLabel, userID string) str
 
 func createExperimentPath() string {
 	return createExperimentPathFormat
+}
+
+func createBucketPath(experimentID string) string {
+	return fmt.Sprintf(createBucketPathFormat, experimentID)
 }
 
 func getExperimentsPath(applicationName, experimentLabel, userID string) string {


### PR DESCRIPTION
Este PR implementa a função para criar um bucket no wasabi. De acordo com a sugestão de @rhnasc e após conversa rápida com @racevedoo decidi não alterar a rota do wasabi para permitir a criação de um experimento já com os buckets. Ambos falaram que não valeria a pena o esforço, então decidi seguir com a estratégia inicial de criar experimento e buckets separadamente mesmo.