### PR TITLE
fix(create experiment): parse start and end time to java format

### DIFF
--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -12,24 +12,24 @@ type Experiment struct {
 	EndTime                  *time.Time        `json:"endTime"`
 	SamplingPercent          float64           `json:"samplingPercent"`
 	Description              string            `json:"description"`
-	HypothesisIsCorrect      string            `json:"hypothesisIsCorrect"`
-	Results                  string            `json:"results"`
-	Rule                     string            `json:"rule"`
-	RuleJSON                 string            `json:"ruleJson"`
-	CreationTime             *time.Time        `json:"creationTime"`
-	ModificationTime         *time.Time        `json:"modificationTime"`
-	State                    ExperimentState   `json:"state"`
-	IsPersonalizationEnabled bool              `json:"isPersonalizationEnabled"`
-	ModelName                string            `json:"modelName"`
-	ModelVersion             string            `json:"modelVersion"`
-	IsRapidExperiment        bool              `json:"isRapidExperiment"`
-	UserCap                  float64           `json:"userCap"`
-	CreatorID                string            `json:"creatorID"`
-	Tags                     []string          `json:"tags"`
-	Buckets                  []*Bucket         `json:"buckets"`
-	ExclusionIDList          []string          `json:"exclusionIdList"`
-	ExperimentPageList       []*ExperimentPage `json:"experimentPageList"`
-	Priority                 float64           `json:"priority"`
+	HypothesisIsCorrect      string            `json:"hypothesisIsCorrect,omitempty"`
+	Results                  string            `json:"results,omitempty"`
+	Rule                     string            `json:"rule,omitempty"`
+	RuleJSON                 string            `json:"ruleJson,omitempty"`
+	CreationTime             *time.Time        `json:"creationTime,omitempty"`
+	ModificationTime         *time.Time        `json:"modificationTime,omitempty"`
+	State                    ExperimentState   `json:"state,omitempty"`
+	IsPersonalizationEnabled bool              `json:"isPersonalizationEnabled,omitempty"`
+	ModelName                string            `json:"modelName,omitempty"`
+	ModelVersion             string            `json:"modelVersion,omitempty"`
+	IsRapidExperiment        bool              `json:"isRapidExperiment,omitempty"`
+	UserCap                  float64           `json:"userCap,omitempty"`
+	CreatorID                string            `json:"creatorID,omitempty"`
+	Tags                     []string          `json:"tags,omitempty"`
+	Buckets                  []*Bucket         `json:"buckets,omitempty"`
+	ExclusionIDList          []string          `json:"exclusionIdList,omitempty"`
+	ExperimentPageList       []*ExperimentPage `json:"experimentPageList,omitempty"`
+	Priority                 float64           `json:"priority,omitempty"`
 }
 
 const (

--- a/http/client.go
+++ b/http/client.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/inloco/go-wasabi/assignments"
 	"github.com/inloco/go-wasabi/experiments"
 )
+
+const timeFormat = "2006-01-02T15:04:05"
 
 type HttpClient struct {
 	http.Client
@@ -56,6 +59,19 @@ func (c *HttpClient) GenerateAssignment(ctx context.Context, experimentLabel str
 
 func (c *HttpClient) CreateExperiment(ctx context.Context, experiment *experiments.Experiment) (*experiments.Experiment, error) {
 	url := c.address + createExperimentPath()
+
+	startTime, err := time.Parse(timeFormat, experiment.StartTime.Format(timeFormat))
+	if err != nil {
+		return nil, err
+	}
+
+	endTime, err := time.Parse(timeFormat, experiment.EndTime.Format(timeFormat))
+	if err != nil {
+		return nil, err
+	}
+
+	experiment.StartTime = &startTime
+	experiment.EndTime = &endTime
 
 	payload, err := json.Marshal(experiment)
 	if err != nil {

--- a/http/client_support.go
+++ b/http/client_support.go
@@ -6,6 +6,7 @@ import (
 )
 
 func executeRequest(req *http.Request) ([]byte, error) {
+	req.Header.Set("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -15,7 +16,7 @@ func executeRequest(req *http.Request) ([]byte, error) {
 	switch {
 	case err != nil:
 		return nil, err
-	case res.StatusCode != http.StatusOK:
+	case res.StatusCode < int(200) || res.StatusCode >= int(300):
 		return nil, handleUnexpectedResponse(res.StatusCode, body)
 	}
 


### PR DESCRIPTION
Ao criar um programa para testar se a lib estava realmente OK percebi que havia um problema com a data enviada para a API porque o wasabi não aceita qualquer formato já que é escrito em Java :angry: por conta disso adicionei um parser para manter só a data e horas no request. Além disso, coloquei para omitir os campos vazios do JSON porque o wasabi reclama também se eles forem passados