### PR TITLE
Feat/get experiment by id

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,4 +14,5 @@ type Client interface {
 	CreateExperiment(ctx context.Context, experiment *experiments.Experiment) (*experiments.Experiment, error)
 	UpdateExperimentState(ctx context.Context, id string, state experiments.ExperimentState) (*experiments.Experiment, error)
 	CreateBucket(ctx context.Context, bucket *experiments.Bucket) (*experiments.Bucket, error)
+	GetExperimentByID(ctx context.Context, experimentID string) (*experiments.Experiment, error)
 }

--- a/http/client.go
+++ b/http/client.go
@@ -150,6 +150,25 @@ func (c *HttpClient) GetExperiments(ctx context.Context) ([]*experiments.Experim
 	return nil, nil
 }
 
-func (c *HttpClient) GetExperimentByID(ctx context.Context, experimentID string) (*assignments.Assignment, error) {
-	return nil, nil
+func (c *HttpClient) GetExperimentByID(ctx context.Context, experimentID string) (*experiments.Experiment, error) {
+	url := c.address + getExperimentByIDPath(experimentID)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		url,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := executeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	experiment := &experiments.Experiment{}
+	err = json.Unmarshal(body, experiment)
+
+	return experiment, err
 }

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -95,6 +95,20 @@ func (suite *HttpTestSuite) TestUpdateExperimentState() {
 	suite.EqualValues(res.State, experiments.ExperimentStateRunning)
 }
 
+func (suite *HttpTestSuite) TestGetExperimentByID() {
+	expected := fixtures.Experiment()
+
+	experiment, err := suite.client.GetExperimentByID(
+		context.Background(),
+		"experiment01",
+	)
+
+	if suite.NoError(err) {
+		suite.EqualValues(expected.ApplicationName, experiment.ApplicationName)
+		suite.EqualValues(expected.Label, experiment.Label)
+	}
+}
+
 func TestHttpTestSuite(t *testing.T) {
 	suite.Run(t, new(HttpTestSuite))
 }

--- a/http/mockserver/get_experiment.go
+++ b/http/mockserver/get_experiment.go
@@ -1,0 +1,24 @@
+package mockserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/inloco/go-wasabi/experiments/fixtures"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	getExperimentByIDPath           = "/api/v1/experiments/experiment01"
+	getExperimentByIDResponseStatus = http.StatusOK
+)
+
+func handleGetExperimentByID(w http.ResponseWriter, req *http.Request) {
+	experiment := fixtures.Experiment()
+	experiment.ID = uuid.NewV4().String()
+
+	payload, _ := json.Marshal(experiment)
+
+	w.Write([]byte(payload))
+	w.WriteHeader(getExperimentByIDResponseStatus)
+}

--- a/http/mockserver/test_server.go
+++ b/http/mockserver/test_server.go
@@ -27,6 +27,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		handleUpdateExperimentState(w, req)
 	case req.Method == http.MethodPost && req.URL.EscapedPath() == createBucketPath:
 		handleCreateBucket(w, req)
+	case req.Method == http.MethodGet && req.URL.EscapedPath() == getExperimentByIDPath:
+		handleGetExperimentByID(w, req)
 	default:
 		failureMessage := fmt.Sprintf(
 			"test server does not recognize the request %s %s",


### PR DESCRIPTION
As long as we are going to create and a experiment for campaigns in for apps we need to be able to recover the experiment with the experiment id.