### PR TITLE
Feat/get experiment buckets

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,4 +16,5 @@ type Client interface {
 	CreateBucket(ctx context.Context, bucket *experiments.Bucket) (*experiments.Bucket, error)
 	GetExperimentByID(ctx context.Context, experimentID string) (*experiments.Experiment, error)
 	GetExperimentBuckets(ctx context.Context, experimentID string) ([]*experiments.Bucket, error)
+	UpdateExperiment(ctx context.Context, id string, experiment *experiments.Experiment) (*experiments.Experiment, error)
 }

--- a/client.go
+++ b/client.go
@@ -15,4 +15,5 @@ type Client interface {
 	UpdateExperimentState(ctx context.Context, id string, state experiments.ExperimentState) (*experiments.Experiment, error)
 	CreateBucket(ctx context.Context, bucket *experiments.Bucket) (*experiments.Bucket, error)
 	GetExperimentByID(ctx context.Context, experimentID string) (*experiments.Experiment, error)
+	GetExperimentBuckets(ctx context.Context, experimentID string) ([]*experiments.Bucket, error)
 }

--- a/experiments/encoding_test.go
+++ b/experiments/encoding_test.go
@@ -226,6 +226,65 @@ func (suite *EncodingTestSuite) TestShallowExperiment() {
 
 }
 
+func (suite *EncodingTestSuite) TestBuckets() {
+	payload := `{
+		"buckets": [{
+			"label": "control",
+			"experimentID": "exp-id",
+			"allocationPercent": 0.4,
+			"description": "description1",
+			"payload": "payload1",
+			"state": "OPEN",
+			"isControl": true
+		},
+		{
+			"label": "treatment",
+			"experimentID": "exp-id",
+			"allocationPercent": 0.6,
+			"description": "description2",
+			"payload": "payload2",
+			"state": "OPEN",
+			"isControl": false
+		}]
+	}
+	`
+
+	aux := &Experiment{}
+	err := json.Unmarshal([]byte(payload), aux)
+
+	if suite.NoError(err) {
+		expectedControlBucket := &Bucket{
+			Label:             "control",
+			ExperimentID:      "exp-id",
+			AllocationPercent: 0.4,
+			Description:       "description1",
+			Payload:           "payload1",
+			State:             "OPEN",
+			IsControl:         true,
+		}
+
+		expectedTreatmentBucket := &Bucket{
+			Label:             "treatment",
+			ExperimentID:      "exp-id",
+			AllocationPercent: 0.6,
+			Description:       "description2",
+			Payload:           "payload2",
+			State:             "OPEN",
+			IsControl:         false,
+		}
+
+		suite.Contains(
+			aux.Buckets,
+			expectedControlBucket,
+		)
+
+		suite.Contains(
+			aux.Buckets,
+			expectedTreatmentBucket,
+		)
+	}
+}
+
 func TestJsonTestSuite(t *testing.T) {
 	suite.Run(t, new(EncodingTestSuite))
 }

--- a/experiments/experiment.go
+++ b/experiments/experiment.go
@@ -5,13 +5,13 @@ import (
 )
 
 type Experiment struct {
-	ID                       string            `json:"id"`
-	Label                    string            `json:"label"`
-	ApplicationName          string            `json:"applicationName"`
-	StartTime                *time.Time        `json:"startTime"`
-	EndTime                  *time.Time        `json:"endTime"`
-	SamplingPercent          float64           `json:"samplingPercent"`
-	Description              string            `json:"description"`
+	ID                       string            `json:"id,omitempty"`
+	Label                    string            `json:"label,omitempty"`
+	ApplicationName          string            `json:"applicationName,omitempty"`
+	StartTime                *time.Time        `json:"startTime,omitempty"`
+	EndTime                  *time.Time        `json:"endTime,omitempty"`
+	SamplingPercent          float64           `json:"samplingPercent,omitempty"`
+	Description              string            `json:"description,omitempty"`
 	HypothesisIsCorrect      string            `json:"hypothesisIsCorrect,omitempty"`
 	Results                  string            `json:"results,omitempty"`
 	Rule                     string            `json:"rule,omitempty"`

--- a/experiments/fixtures/fixtures.go
+++ b/experiments/fixtures/fixtures.go
@@ -6,8 +6,13 @@ import (
 	"github.com/inloco/go-wasabi/experiments"
 )
 
+const (
+	startDate     = "2020-03-04"
+	layoutDateISO = "2006-01-02"
+)
+
 func Experiment() *experiments.Experiment {
-	now := time.Now()
+	now, _ := time.Parse(layoutDateISO, "2020-03-04")
 	tomorrow := now.AddDate(0, 0, 1)
 
 	return &experiments.Experiment{
@@ -36,10 +41,17 @@ func Buckets() []*experiments.Bucket {
 	}
 }
 
-func ExperimentCreated() *experiments.Experiment {
+func ExperimentToUpdateState() *experiments.Experiment {
 	experiment := Experiment()
 	experiment.ID = "experiment_id"
 	experiment.State = experiments.ExperimentStateDraft
+
+	return experiment
+}
+
+func ExperimentToUpdate() *experiments.Experiment {
+	experiment := Experiment()
+	experiment.ID = "experiment_update_id"
 
 	return experiment
 }

--- a/http/client.go
+++ b/http/client.go
@@ -172,3 +172,26 @@ func (c *HttpClient) GetExperimentByID(ctx context.Context, experimentID string)
 
 	return experiment, err
 }
+
+func (c *HttpClient) GetExperimentBuckets(ctx context.Context, experimentID string) ([]*experiments.Bucket, error) {
+	url := c.address + getExperimentBucketsPath(experimentID)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		url,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := executeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	experimentWithOnlyBuckets := &experiments.Experiment{}
+	err = json.Unmarshal(body, experimentWithOnlyBuckets)
+
+	return experimentWithOnlyBuckets.Buckets, err
+}

--- a/http/client.go
+++ b/http/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/inloco/go-wasabi/assignments"
 	"github.com/inloco/go-wasabi/experiments"
@@ -60,18 +59,18 @@ func (c *HttpClient) GenerateAssignment(ctx context.Context, experimentLabel str
 func (c *HttpClient) CreateExperiment(ctx context.Context, experiment *experiments.Experiment) (*experiments.Experiment, error) {
 	url := c.address + createExperimentPath()
 
-	startTime, err := time.Parse(timeFormat, experiment.StartTime.Format(timeFormat))
+	startTime, err := removeTimezoneFromTime(experiment.StartTime)
 	if err != nil {
 		return nil, err
 	}
 
-	endTime, err := time.Parse(timeFormat, experiment.EndTime.Format(timeFormat))
+	endTime, err := removeTimezoneFromTime(experiment.EndTime)
 	if err != nil {
 		return nil, err
 	}
 
-	experiment.StartTime = &startTime
-	experiment.EndTime = &endTime
+	experiment.StartTime = startTime
+	experiment.EndTime = endTime
 
 	payload, err := json.Marshal(experiment)
 	if err != nil {
@@ -194,4 +193,45 @@ func (c *HttpClient) GetExperimentBuckets(ctx context.Context, experimentID stri
 	err = json.Unmarshal(body, experimentWithOnlyBuckets)
 
 	return experimentWithOnlyBuckets.Buckets, err
+}
+
+func (c *HttpClient) UpdateExperiment(ctx context.Context, id string, experiment *experiments.Experiment) (*experiments.Experiment, error) {
+	url := c.address + updateExperimentPath(id)
+
+	if experiment.StartTime != nil {
+		startTime, err := removeTimezoneFromTime(experiment.StartTime)
+		if err != nil {
+			return nil, err
+		}
+		experiment.StartTime = startTime
+	}
+
+	if experiment.EndTime != nil {
+		endTime, err := removeTimezoneFromTime(experiment.EndTime)
+		if err != nil {
+			return nil, err
+		}
+		experiment.EndTime = endTime
+	}
+
+	payload, err := json.Marshal(experiment)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(c.login, c.password)
+
+	body, err := executeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	experimentUpdated := &experiments.Experiment{}
+	err = json.Unmarshal(body, experimentUpdated)
+	return experimentUpdated, err
 }

--- a/http/client_support.go
+++ b/http/client_support.go
@@ -3,6 +3,7 @@ package http
 import (
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 func executeRequest(req *http.Request) ([]byte, error) {
@@ -21,4 +22,12 @@ func executeRequest(req *http.Request) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func removeTimezoneFromTime(t *time.Time) (*time.Time, error) {
+	newTime, err := time.Parse(timeFormat, t.Format(timeFormat))
+	if err != nil {
+		return nil, err
+	}
+	return &newTime, nil
 }

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -85,7 +85,7 @@ func (suite *HttpTestSuite) TestCreateBucket() {
 }
 
 func (suite *HttpTestSuite) TestUpdateExperimentState() {
-	experiment := fixtures.ExperimentCreated()
+	experiment := fixtures.ExperimentToUpdateState()
 
 	res, err := suite.client.UpdateExperimentState(context.Background(), experiment.ID, experiments.ExperimentStateRunning)
 
@@ -120,6 +120,18 @@ func (suite *HttpTestSuite) TestGetExperimentBuckets() {
 	if suite.NoError(err) {
 		suite.ElementsMatch(expected, buckets)
 	}
+}
+
+func (suite *HttpTestSuite) TestUpdateExperiment() {
+	experiment := fixtures.ExperimentToUpdate()
+
+	res, err := suite.client.UpdateExperiment(context.Background(), experiment.ID, experiment)
+
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+	suite.Require().NotEmpty(res.ID)
+
+	suite.EqualValues(experiment, res)
 }
 
 func TestHttpTestSuite(t *testing.T) {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -109,6 +109,19 @@ func (suite *HttpTestSuite) TestGetExperimentByID() {
 	}
 }
 
+func (suite *HttpTestSuite) TestGetExperimentBuckets() {
+	expected := fixtures.Buckets()
+
+	buckets, err := suite.client.GetExperimentBuckets(
+		context.Background(),
+		"experiment01",
+	)
+
+	if suite.NoError(err) {
+		suite.ElementsMatch(expected, buckets)
+	}
+}
+
 func TestHttpTestSuite(t *testing.T) {
 	suite.Run(t, new(HttpTestSuite))
 }

--- a/http/mockserver/get_experiment_buckets.go
+++ b/http/mockserver/get_experiment_buckets.go
@@ -1,0 +1,25 @@
+package mockserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/inloco/go-wasabi/experiments"
+	"github.com/inloco/go-wasabi/experiments/fixtures"
+)
+
+const (
+	getExperimentBucketsPath           = "/api/v1/experiments/experiment01/buckets"
+	getExperimentBucketsResponseStatus = http.StatusOK
+)
+
+func handleGetExperimentBuckets(w http.ResponseWriter, req *http.Request) {
+	experiment := &experiments.Experiment{
+		Buckets: fixtures.Buckets(),
+	}
+
+	payload, _ := json.Marshal(experiment)
+
+	w.Write([]byte(payload))
+	w.WriteHeader(getExperimentBucketsResponseStatus)
+}

--- a/http/mockserver/test_server.go
+++ b/http/mockserver/test_server.go
@@ -31,6 +31,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		handleGetExperimentByID(w, req)
 	case req.Method == http.MethodGet && req.URL.EscapedPath() == getExperimentBucketsPath:
 		handleGetExperimentBuckets(w, req)
+	case req.Method == http.MethodPut && req.URL.EscapedPath() == updateExperimentPath:
+		handleUpdateExperiment(w, req)
 	default:
 		failureMessage := fmt.Sprintf(
 			"test server does not recognize the request %s %s",

--- a/http/mockserver/test_server.go
+++ b/http/mockserver/test_server.go
@@ -29,6 +29,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		handleCreateBucket(w, req)
 	case req.Method == http.MethodGet && req.URL.EscapedPath() == getExperimentByIDPath:
 		handleGetExperimentByID(w, req)
+	case req.Method == http.MethodGet && req.URL.EscapedPath() == getExperimentBucketsPath:
+		handleGetExperimentBuckets(w, req)
 	default:
 		failureMessage := fmt.Sprintf(
 			"test server does not recognize the request %s %s",

--- a/http/mockserver/update_experiment.go
+++ b/http/mockserver/update_experiment.go
@@ -12,14 +12,25 @@ import (
 const (
 	updateExperimentStatePath           = "/api/v1/experiments/experiment_id"
 	updateExperimentStateResponseStatus = http.StatusOK
+	updateExperimentPath                = "/api/v1/experiments/experiment_update_id"
+	updateExperimentResponseStatus      = http.StatusOK
 )
 
 func handleUpdateExperimentState(w http.ResponseWriter, req *http.Request) {
-	experiment := fixtures.ExperimentCreated()
+	experiment := fixtures.ExperimentToUpdateState()
 	experiment.State = experiments.ExperimentStateRunning
 
 	payload, _ := json.Marshal(experiment)
 
 	w.Write([]byte(payload))
 	w.WriteHeader(updateExperimentStateResponseStatus)
+}
+
+func handleUpdateExperiment(w http.ResponseWriter, req *http.Request) {
+	experiment := fixtures.ExperimentToUpdate()
+
+	payload, _ := json.Marshal(experiment)
+
+	w.Write([]byte(payload))
+	w.WriteHeader(updateExperimentResponseStatus)
 }

--- a/http/paths.go
+++ b/http/paths.go
@@ -7,11 +7,12 @@ import (
 const (
 	generateAssignmentPathFormat = "/api/v1/assignments/applications/%s/experiments/%s/users/%s"
 
-	createExperimentPathFormat  = "/api/v1/experiments"
-	updateExperimentPathFormat  = "/api/v1/experiments/%s"
-	createBucketPathFormat      = "/api/v1/experiments/%s/buckets"
-	getExperimentsPathFormat    = "/api/v1/experiments"
-	getExperimentByIDPathFormat = "/api/v1/experiments/%s"
+	createExperimentPathFormat     = "/api/v1/experiments"
+	updateExperimentPathFormat     = "/api/v1/experiments/%s"
+	createBucketPathFormat         = "/api/v1/experiments/%s/buckets"
+	getExperimentsPathFormat       = "/api/v1/experiments"
+	getExperimentByIDPathFormat    = "/api/v1/experiments/%s"
+	getExperimentBucketsPathFormat = "/api/v1/experiments/%s/buckets"
 )
 
 func generateAssignmentPath(applicationName, experimentLabel, userID string) string {
@@ -42,6 +43,13 @@ func getExperimentsPath(applicationName, experimentLabel, userID string) string 
 func getExperimentByIDPath(experimentID string) string {
 	return fmt.Sprintf(
 		getExperimentByIDPathFormat,
+		experimentID,
+	)
+}
+
+func getExperimentBucketsPath(experimentID string) string {
+	return fmt.Sprintf(
+		getExperimentBucketsPathFormat,
 		experimentID,
 	)
 }

--- a/mock.go
+++ b/mock.go
@@ -45,3 +45,8 @@ func (m *MockedClient) GetExperimentBuckets(ctx context.Context, experimentID st
 	args := m.Called(experimentID)
 	return args.Get(0).([]*experiments.Bucket), args.Error(1)
 }
+
+func (m *MockedClient) UpdateExperiment(ctx context.Context, id string, experiment *experiments.Experiment) (*experiments.Experiment, error) {
+	args := m.Called(id, experiment)
+	return args.Get(0).(*experiments.Experiment), args.Error(1)
+}

--- a/mock.go
+++ b/mock.go
@@ -40,3 +40,8 @@ func (m *MockedClient) GetExperimentByID(ctx context.Context, experimentID strin
 	args := m.Called(experimentID)
 	return args.Get(0).(*experiments.Experiment), args.Error(1)
 }
+
+func (m *MockedClient) GetExperimentBuckets(ctx context.Context, experimentID string) ([]*experiments.Bucket, error) {
+	args := m.Called(experimentID)
+	return args.Get(0).([]*experiments.Bucket), args.Error(1)
+}


### PR DESCRIPTION
The method GetExperimentByID doesn't return buckets. As long as we need to be able to return the control group percentage in for apps campaign service, we need to get the buckets with the experiment id.