### PR TITLE
Fix/encode user id when generating url

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/inloco/go-wasabi/assignments"
 	"github.com/inloco/go-wasabi/experiments"
@@ -34,11 +35,12 @@ func NewHttpClient(address, applicationName, login, password string) *HttpClient
 
 func (c *HttpClient) GenerateAssignment(ctx context.Context, experimentLabel string, userID string) (*assignments.Assignment, error) {
 
-	url := c.address + generateAssignmentPath(c.applicationName, experimentLabel, userID)
+	userIDEscaped := url.PathEscape(userID)
+	urlPath := c.address + generateAssignmentPath(c.applicationName, experimentLabel, userIDEscaped)
 
 	req, err := http.NewRequest(
 		http.MethodGet,
-		url,
+		urlPath,
 		nil,
 	)
 	if err != nil {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -43,7 +43,7 @@ func (suite *HttpTestSuite) TestGenerateAssignment() {
 	assignment, err := suite.client.GenerateAssignment(
 		context.Background(),
 		"JustToTestGenerateAssignment",
-		"userID1",
+		"user/ID1",
 	)
 
 	if suite.NoError(err) {

--- a/http/mockserver/generate_assignment.go
+++ b/http/mockserver/generate_assignment.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	generateAssignmentPath = "/api/v1/assignments/applications/test/experiments/JustToTestGenerateAssignment/users/userID1"
+	generateAssignmentPath = "/api/v1/assignments/applications/test/experiments/JustToTestGenerateAssignment/users/user%2FID1"
 
 	generateAssignemntResponseStatus  = http.StatusOK
 	generateAssignmentResponsePayload = `{


### PR DESCRIPTION
When using the generate assign function, we may pass a user id with reserved characters such as: `/`. To solve that, this PR encodes the user id before generating url.